### PR TITLE
Remove GTM code from nginx docs theme

### DIFF
--- a/_themes/docs-theme/layout.html
+++ b/_themes/docs-theme/layout.html
@@ -152,26 +152,9 @@
 {%- endblock %}
 {%- block extrahead %} {% endblock %}
     
-  <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-K5HG9JT');</script>
-  <!-- End Google Tag Manager -->
-
 </head>
 <body>
-  <!-- GDPR Section Start -->
-  
-  <!-- GDPR Section End -->
-
-  <!-- Header Section Start -->
-
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K5HG9JT"
-  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
+ 
 
   <div id="page" class="hfeed site page-{{ pagename | replace('/','-') }}">
   <!-- Header Section Start -->


### PR DESCRIPTION
Hi! I discovered that this lab is using the google analytics code for the NGINX docs site, which is messing with our analytics data. This PR takes the GTM code out of the theme. 